### PR TITLE
Migration to Kotlin BLE Library 2.0.0-alpha07

### DIFF
--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/bluetooth/DeviceState.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/bluetooth/DeviceState.kt
@@ -57,6 +57,7 @@ internal fun ConnectionState.toDeviceState(
 	ConnectionState.Disconnecting -> DeviceState.Disconnecting
 	is ConnectionState.Disconnected ->
 		when (reason) {
+			null,
 			ConnectionState.Disconnected.Reason.Success,
             ConnectionState.Disconnected.Reason.Cancelled ->
 				DeviceState.Disconnected(
@@ -77,8 +78,8 @@ internal fun ConnectionState.toDeviceState(
 			ConnectionState.Disconnected.Reason.UnsupportedAddress,
 			ConnectionState.Disconnected.Reason.InsufficientAuthentication ->
 				DeviceState.Disconnected(Reason.BONDING_FAILED)
-			is ConnectionState.Disconnected.Reason.Unknown ->
+			is ConnectionState.Disconnected.Reason.Unknown,
+			ConnectionState.Disconnected.Reason.UnsupportedConfiguration ->
 				DeviceState.Disconnected(Reason.FAILED_TO_CONNECT)
 		}
-	ConnectionState.Closed -> DeviceState.Disconnected()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,7 +45,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:2.9-1")
+            from("no.nordicsemi.android.gradle:version-catalog:2.9-2")
         }
     }
 }


### PR DESCRIPTION
Changes:
* `Closed` state removed from `ConnectionState`.
* `reason` in `ConnectionState.Disconnected` is nullable and set to null for the initial state.
* New reason added: `UnsupportedConfiguration` (when the phone fails to connect due to its own bugs)