### PR TITLE
Bugfix: Disconnection and cancellaton issues fixed

### DIFF
--- a/app/src/main/java/no/nordicsemi/memfault/di/MemfaultModule.kt
+++ b/app/src/main/java/no/nordicsemi/memfault/di/MemfaultModule.kt
@@ -38,7 +38,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(ViewModelComponent::class)

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/MemfaultDiagnosticsManager.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/MemfaultDiagnosticsManager.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.flow.StateFlow
 import no.nordicsemi.kotlin.ble.client.android.CentralManager
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
 import no.nordicsemi.kotlin.ble.client.android.native
-import no.nordicsemi.memfault.observability.internal.MemfaultScope
+import no.nordicsemi.memfault.observability.internal.Scope
 
 /**
  * Class responsible for managing connection with the remote IoT device which supports
@@ -93,7 +93,7 @@ interface MemfaultDiagnosticsManager {
      * @throws IllegalStateException if the manager is already connected to a peripheral.
      */
     fun connect(context: Context, device: BluetoothDevice) {
-        val centralManager = CentralManager.Factory.native(context, MemfaultScope)
+        val centralManager = CentralManager.Factory.native(context, Scope)
         val peripheral = centralManager.getPeripheralById(device.address)!!
         connect(peripheral, centralManager)
     }

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/MemfaultDiagnosticsManager.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/MemfaultDiagnosticsManager.kt
@@ -67,7 +67,7 @@ interface MemfaultDiagnosticsManager {
     /**
      * Function used to connect to the selected Bluetooth LE peripheral.
      *
-     * The peripheral must support Memfault Diagnostic Service.
+     * The peripheral must support Monitoring & Diagnostic Service.
      *
      * Chunks upload will start immediately after establishing the connection.
      *
@@ -84,7 +84,7 @@ interface MemfaultDiagnosticsManager {
     /**
      * Function used to connect to the selected Bluetooth LE peripheral.
      *
-     * The peripheral must support Memfault Diagnostic Service.
+     * The peripheral must support Monitoring & Diagnostic Service.
      *
      * Chunks upload will start immediately after establishing the connection.
      *

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/MemfaultDiagnosticsManagerImpl.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/MemfaultDiagnosticsManagerImpl.kt
@@ -52,7 +52,7 @@ import no.nordicsemi.kotlin.ble.client.android.Peripheral
 import no.nordicsemi.memfault.observability.bluetooth.DeviceState
 import no.nordicsemi.memfault.observability.bluetooth.MemfaultDiagnosticsService
 import no.nordicsemi.memfault.observability.data.PersistentChunkQueue
-import no.nordicsemi.memfault.observability.internal.MemfaultScope
+import no.nordicsemi.memfault.observability.internal.Scope
 import no.nordicsemi.memfault.observability.internet.MemfaultCloudManager
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -74,7 +74,7 @@ internal class MemfaultDiagnosticsManagerImpl(
         check(service == null) { "Already connected to a peripheral" }
 
         // Set up the collector for observable chunks from the device.
-        MemfaultScope.launch {
+        Scope.launch {
             service = MemfaultDiagnosticsService(centralManager, peripheral, this)
                 .apply {
                     var connection: Job? = null

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/bluetooth/MemfaultDiagnosticsService.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/bluetooth/MemfaultDiagnosticsService.kt
@@ -261,6 +261,12 @@ class MemfaultDiagnosticsService {
 					// is not supported (disconnect() method called), or the connection was cancelled
 					// by the user.
 					is ConnectionState.Disconnected -> {
+						if (state.reason is ConnectionState.Disconnected.Reason.UnsupportedAddress) {
+							// This error is thrown in AutoConnect connection when there is no
+							// bonding. The library will transition to Direct connection automatically.
+							// Don't report this state.
+							return@onEach
+						}
 						_state.emit(state.toDeviceState(notSupported, bondingFailed))
 						if (state.isUserInitiated /* (includes not supported) */ ||
 							state.reason is ConnectionState.Disconnected.Reason.UnsupportedConfiguration) {

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/bluetooth/MemfaultDiagnosticsService.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/bluetooth/MemfaultDiagnosticsService.kt
@@ -226,7 +226,7 @@ class MemfaultDiagnosticsService {
 	private suspend fun CoroutineScope.connect(
 		centralManager: CentralManager,
 		peripheral: Peripheral,
-	) {
+	): Nothing {
 		// Observe the peripheral bond state to catch bonding failures.
 		var wasBonding = false
 		peripheral.bondState

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/bluetooth/MemfaultDiagnosticsService.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/bluetooth/MemfaultDiagnosticsService.kt
@@ -67,6 +67,7 @@ import no.nordicsemi.kotlin.ble.core.Manager
 import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.WriteType
 import no.nordicsemi.memfault.observability.data.MemfaultConfig
+import no.nordicsemi.memfault.observability.internal.AuthorisationHeader
 import org.slf4j.LoggerFactory
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/bluetooth/MemfaultDiagnosticsService.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/bluetooth/MemfaultDiagnosticsService.kt
@@ -217,6 +217,11 @@ class MemfaultDiagnosticsService {
 		job = null
 	}
 
+	/**
+	 * This method connects the the peripheral and starts observing its state.
+	 *
+	 * It suspends until the scope is cancelled.
+	 */
 	private suspend fun CoroutineScope.connect(
 		centralManager: CentralManager,
 		peripheral: Peripheral,

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/data/Chunk.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/data/Chunk.kt
@@ -2,12 +2,12 @@ package no.nordicsemi.memfault.observability.data
 
 /**
  * Represents a chunk of Memfault Observability data received from the device
- * using Memfault Diagnostics Service.
+ * using Monitoring & Diagnostics Service.
  *
  * @property chunkNumber The number of the chunk, in range from 0-31
  * @property data The bytes received.
  * @property deviceId The device ID of the device from which the chunk was received.
- * @property isUploaded A flag indicating whether the chunk has been uploaded to the Memfault Cloud.
+ * @property isUploaded A flag indicating whether the chunk has been uploaded to the cloud.
  */
 data class Chunk(
     val chunkNumber: Int,

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/data/PersistentChunkQueue.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/data/PersistentChunkQueue.kt
@@ -5,9 +5,9 @@ import androidx.room.Room
 import com.memfault.cloud.sdk.ChunkQueue
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import no.nordicsemi.memfault.observability.db.ChunksDatabase
-import no.nordicsemi.memfault.observability.db.toChunk
-import no.nordicsemi.memfault.observability.db.toEntity
+import no.nordicsemi.memfault.observability.internal.db.ChunksDatabase
+import no.nordicsemi.memfault.observability.internal.db.toChunk
+import no.nordicsemi.memfault.observability.internal.db.toEntity
 
 /**
  * An implementation of [ChunkQueue] that stores chunks in a persistent database.

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/AuthorisationHeader.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/AuthorisationHeader.kt
@@ -1,4 +1,4 @@
-package no.nordicsemi.memfault.observability.bluetooth
+package no.nordicsemi.memfault.observability.internal
 
 /**
  * This class parses the Authorization Header read from a characteristic.

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/ChunkSenderExt.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/ChunkSenderExt.kt
@@ -29,11 +29,10 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.memfault.observability.internet
+package no.nordicsemi.memfault.observability.internal
 
 import com.memfault.cloud.sdk.ChunkSender
 import com.memfault.cloud.sdk.SendChunksCallback
-import kotlinx.coroutines.delay
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/Scope.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/Scope.kt
@@ -35,4 +35,4 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 
-internal val MemfaultScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+internal val Scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/db/ChunkEntity.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/db/ChunkEntity.kt
@@ -29,7 +29,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.memfault.observability.db
+package no.nordicsemi.memfault.observability.internal.db
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/db/ChunksDao.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/db/ChunksDao.kt
@@ -29,13 +29,28 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.memfault.observability.db
+package no.nordicsemi.memfault.observability.internal.db
 
-import androidx.room.Database
-import androidx.room.RoomDatabase
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
-@Database(entities = [ChunkEntity::class], version = 1)
-internal abstract class ChunksDatabase : RoomDatabase() {
+@Dao
+internal interface ChunksDao {
 
-    abstract fun chunksDao(): ChunksDao
+    @Query("SELECT * FROM chunks WHERE device_id = :deviceId ORDER BY id DESC")
+    fun getAll(deviceId: String): Flow<List<ChunkEntity>>
+
+    @Query("SELECT * FROM chunks WHERE is_uploaded = 0 AND device_id = :deviceId ORDER BY id ASC LIMIT :limit")
+    fun getNotUploaded(limit: Int, deviceId: String): List<ChunkEntity>
+
+    @Query("UPDATE chunks SET is_uploaded = 1 WHERE is_uploaded IN (SELECT is_uploaded FROM chunks WHERE is_uploaded = 0 AND device_id = :deviceId ORDER BY id ASC LIMIT :limit)")
+    fun markUploaded(limit: Int, deviceId: String)
+
+    @Insert
+    fun insert(chunk: ChunkEntity)
+
+    @Query("DELETE FROM chunks WHERE is_uploaded = 1")
+    fun clearUploaded()
 }

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/db/ChunksDatabase.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internal/db/ChunksDatabase.kt
@@ -29,28 +29,13 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.memfault.observability.db
+package no.nordicsemi.memfault.observability.internal.db
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.Query
-import kotlinx.coroutines.flow.Flow
+import androidx.room.Database
+import androidx.room.RoomDatabase
 
-@Dao
-internal interface ChunksDao {
+@Database(entities = [ChunkEntity::class], version = 1)
+internal abstract class ChunksDatabase : RoomDatabase() {
 
-    @Query("SELECT * FROM chunks WHERE device_id = :deviceId ORDER BY id DESC")
-    fun getAll(deviceId: String): Flow<List<ChunkEntity>>
-
-    @Query("SELECT * FROM chunks WHERE is_uploaded = 0 AND device_id = :deviceId ORDER BY id ASC LIMIT :limit")
-    fun getNotUploaded(limit: Int, deviceId: String): List<ChunkEntity>
-
-    @Query("UPDATE chunks SET is_uploaded = 1 WHERE is_uploaded IN (SELECT is_uploaded FROM chunks WHERE is_uploaded = 0 AND device_id = :deviceId ORDER BY id ASC LIMIT :limit)")
-    fun markUploaded(limit: Int, deviceId: String)
-
-    @Insert
-    fun insert(chunk: ChunkEntity)
-
-    @Query("DELETE FROM chunks WHERE is_uploaded = 1")
-    fun clearUploaded()
+    abstract fun chunksDao(): ChunksDao
 }

--- a/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internet/MemfaultCloudManager.kt
+++ b/lib/observability/src/main/java/no/nordicsemi/memfault/observability/internet/MemfaultCloudManager.kt
@@ -40,6 +40,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import no.nordicsemi.memfault.observability.data.MemfaultConfig
 import no.nordicsemi.memfault.observability.data.PersistentChunkQueue
+import no.nordicsemi.memfault.observability.internal.ChunkSenderResult
+import no.nordicsemi.memfault.observability.internal.send
 import java.net.URL
 import kotlin.time.Duration.Companion.seconds
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,7 +45,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:2.9-2")
+            from("no.nordicsemi.android.gradle:version-catalog:2.9-3")
         }
     }
 }


### PR DESCRIPTION
When the `MemfaultDiagnosticsManager` was disconnected manually, with `disconnect()` the states were not propagated, leaving it in `Connecting` state.

Now the disconnect method makes sure that the device disconnects propertly, states are reset and all flow collectors and coroutines are cancelled.

Also, internal types were moved to `internal` package for better readability.